### PR TITLE
Use license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,5 @@
 		"type": "git",
 		"url": "git@github.com:webpack/url-loader.git"
 	},
-	"licenses": [
-		{
-			"type": "MIT",
-			"url": "http://www.opensource.org/licenses/mit-license.php"
-		}
-	]
+	"license": "MIT"
 }


### PR DESCRIPTION
Array deprecated in `npm@2.10.0`

https://github.com/npm/npm/blob/master/doc/files/package.json.md#license

Last one! phew :laughing: 