### PR TITLE
An idea for CDN-ification of resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# url loader for webpack
+# CDN and data url loader for webpack
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -4,22 +4,18 @@
 
 [Documentation: Using loaders](http://webpack.github.io/docs/using-loaders.html)
 
-The `url` loader works like the `file` loader, but can return a Data Url if the file is smaller than a limit.
+The `cdn-url` loader works like the `file` loader, but can return a Data Url if the file is smaller than a limit. Otherwise it returns a link to a specified resource on a CDN.
 
 The limit can be specified with a query parameter. (Defaults to no limit)
 
-If the file is greater than the limit the [`file-loader`](https://github.com/webpack/file-loader) is used and all query parameters are passed to it.
+If the file is greater than the limit the CDN link is used.
 
 ``` javascript
-require("url?limit=10000!./file.png");
+require("cdn-url?limit=10000!./file.png");
 // => DataUrl if "file.png" is smaller that 10kb
 
-require("url?mimetype=image/png!./file.png");
+require("cdn-url?mimetype=image/png!./file.png");
 // => Specify mimetype for the file (Otherwise it's inferred from extension.)
-
-require("url?prefix=img/!./file.png");
-// => Parameters for the file-loader are valid too
-//    They are passed to the file-loader if used.
 ```
 
 ## License

--- a/index.js
+++ b/index.js
@@ -15,8 +15,7 @@ module.exports = function(content) {
 	if(limit <= 0 || content.length < limit) {
 		return "module.exports = " + JSON.stringify("data:" + (mimetype ? mimetype + ";" : "") + "base64," + content.toString("base64"));
 	} else {
-		var fileLoader = require("file-loader");
-		return fileLoader.call(this, content);
+		return "module.exports = " + query.cdnUrl + query.name;
 	}
 }
 module.exports.raw = true;

--- a/index.js
+++ b/index.js
@@ -15,7 +15,13 @@ module.exports = function(content) {
 	if(limit <= 0 || content.length < limit) {
 		return "module.exports = " + JSON.stringify("data:" + (mimetype ? mimetype + ";" : "") + "base64," + content.toString("base64"));
 	} else {
-		return "module.exports = " + query.cdnUrl + query.name;
+		var url = loaderUtils.interpolateName(this, query.name, {
+				context: query.context || this.options.context,
+				content: content,
+				regExp: query.regExp
+			});
+		this.emitFile(url, content);
+		return "module.exports = " + JSON.stringify(query.cdnUrl + url);
 	}
 }
 module.exports.raw = true;

--- a/package.json
+++ b/package.json
@@ -7,9 +7,6 @@
     "loader-utils": "0.2.x",
     "mime": "1.2.x"
   },
-  "peerDependencies": {
-    "file-loader": "*"
-  },
   "repository": {
     "type": "git",
     "url": "git@github.com:webpack/url-loader.git"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "url-loader",
-  "version": "0.5.7",
-  "author": "Tobias Koppers @sokra",
-  "description": "url loader module for webpack",
+  "name": "cdn-url-loader",
+  "version": "0.1.0",
+  "author": "Jason Dufair jase@dufair.org and Tobias Koppers @sokra",
+  "description": "CDN and url loader module for webpack",
   "dependencies": {
     "loader-utils": "0.2.x",
     "mime": "1.2.x"


### PR DESCRIPTION
Hi - I did this for a project I'm working on. Might be nice to actually include this functionality in file-loader so one can specify a CDN url prefix. Then you can upload resources from, say, /img to the CDN as part of the deployment process. If you want a pull request on file-loader instead, let me know.