### PR TITLE
Bumb version of mime

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "url loader module for webpack",
   "dependencies": {
     "loader-utils": "0.2.x",
-    "mime": "1.2.x"
+    "mime": "1.3.x"
   },
   "peerDependencies": {
     "file-loader": "*"


### PR DESCRIPTION
The 1.2.x versions of [mime](https://github.com/broofa/node-mime) is 3 years old and lacks support for many common mime types today.