### PR TITLE
Improving README by explicitly stating unit of measure for limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 [Documentation: Using loaders](http://webpack.github.io/docs/using-loaders.html)
 
-The `url` loader works like the `file` loader, but can return a Data Url if the file is smaller than a limit.
+The `url` loader works like the `file` loader, but can return a Data Url if the file is smaller than a byte limit.
 
 The limit can be specified with a query parameter. (Defaults to no limit)
 
-If the file is greater than the limit the [`file-loader`](https://github.com/webpack/file-loader) is used and all query parameters are passed to it.
+If the file is greater than the limit (in bytes) the [`file-loader`](https://github.com/webpack/file-loader) is used and all query parameters are passed to it.
 
 ``` javascript
 require("url?limit=10000!./file.png");


### PR DESCRIPTION
This took a while to track down and verify, had to look at the source,
then look at the Webpack docs which say "In the simple case, when only a
single loader is applied to the resource, the loader is called with one
parameter: the content of the resource file as string." That page
doesn't mention the `raw` option. Then discovered raw, discovered it was
a Buffer, and had to look up what Buffer.length is here:
https://nodejs.org/api/buffer.html#buffer_buf_length So I believe this
commit is correct.