### PR TITLE
Update README with -loader suffix on examples to reflect the change in Webpack 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ The limit can be specified with a query parameter. (Defaults to no limit)
 If the file is greater than the limit (in bytes) the [`file-loader`](https://github.com/webpack/file-loader) is used and all query parameters are passed to it.
 
 ``` javascript
-require("url?limit=10000!./file.png");
+require("url-loader?limit=10000!./file.png");
 // => DataUrl if "file.png" is smaller than 10kb
 
-require("url?mimetype=image/png!./file.png");
+require("url-loader?mimetype=image/png!./file.png");
 // => Specify mimetype for the file (Otherwise it's inferred from extension.)
 
-require("url?prefix=img/!./file.png");
+require("url-loader?prefix=img/!./file.png");
 // => Parameters for the file-loader are valid too
 //    They are passed to the file-loader if used.
 ```


### PR DESCRIPTION
Summary:
----

Webpack v2.1.0-beta.26 introduced a breaking change to require loaders to have the `-loader` suffix. 

This PR updates the README to show that pattern as an example instead of using the shorthand naming.

cc: @sokra @SpaceK33z 